### PR TITLE
Remove avx* instructions using CXX_FLAGS

### DIFF
--- a/Singularity.0.1.0
+++ b/Singularity.0.1.0
@@ -17,7 +17,7 @@ Version 0.1.0
   cd racon-v1.4.3
   mkdir build
   cd build/
-  cmake -DCMAKE_BUILD_TYPE=Release ..
+  CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-mno-avx2 -mno-avx" ..
   make
   make install
 
@@ -25,7 +25,7 @@ Version 0.1.0
   cd /opt
   curl -OL https://github.com/lh3/minimap2/releases/download/v2.17/minimap2-2.17_x64-linux.tar.bz2
 
-  tar -xjf minimap2-2.17_x64-linux.tar.bz2
+  tar --no-same-owner -xjf minimap2-2.17_x64-linux.tar.bz2
   cd minimap2-2.17_x64-linux
   install -dm0755 /usr/local/bin
   install -Dm0755 k8 /usr/local/bin


### PR DESCRIPTION
- similar to powerPlant/racon-srf#1
- fix 'Cannot change ownership to uid/gid: Invalid argument' when installing minimap2